### PR TITLE
Remove extra word

### DIFF
--- a/src/chapters/chapter7.js
+++ b/src/chapters/chapter7.js
@@ -95,7 +95,7 @@ const _Chapter = ({currentSection, inventory, chapterId}) => {
         partially to blame.”
       </p>
       <p>
-        She’s worried about you and wants you to see it. “I called you over because it sounded from
+        She’s worried about you and wants you to see it. “I called you over because it sounded
         like you could use some company. Plus Hank
         made too much spaghetti again.” She touches your arm. “We’re here for you. And I’m no psychic,
         but we’re almost to the bottom of this thing. I know it.”


### PR DESCRIPTION
Changed “it sounded from like” to “it sounded like”, but this may be American dialect I’m not familiar with, in which case please feel free to reject this pull request.